### PR TITLE
Add basic subject model and component for subject display

### DIFF
--- a/app/components/subject-display.js
+++ b/app/components/subject-display.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/app/models/subject.js
+++ b/app/models/subject.js
@@ -1,0 +1,8 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  subject: attr(),
+  sub_categories: attr(),
+  photo: "This is a photo link"
+});

--- a/app/templates/components/subject-display.hbs
+++ b/app/templates/components/subject-display.hbs
@@ -1,0 +1,2 @@
+<h4>{{subject.subject}}</h4>
+<hr>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -37,4 +37,29 @@ export default function() {
       }]
     };
   });
+      this.get('/subjects', function() {
+    return {
+      data: [{
+        type: 'subjects',
+        id: 1,
+        attributes: {
+          subject: 'Biology',
+          sub_categories: ["Medicine", "Computational Biology, Pathogens"]
+
+        }
+      },
+        {
+        type: 'subjects',
+        id: 2,
+        attributes: {
+          subject: 'Psychology',
+          sub_categories: ["Medicine", "Computational Biology, Pathogens"]
+
+        }
+      },
+
+
+      ]
+    };
+  });
 }

--- a/tests/integration/components/subject-display-test.js
+++ b/tests/integration/components/subject-display-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('subject-display', 'Integration | Component | subject display', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{subject-display}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#subject-display}}
+      template block text
+    {{/subject-display}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/models/subject-test.js
+++ b/tests/unit/models/subject-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('subject', 'Unit | Model | subject', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
Adding in a basic subject model and component for subject display(Terron just need to change this). Just need to use `return this.store.findAll('subject');` in your route JS file to get access to subjects. Add more subjects to mirage/config.yml to make your list what it needs to be. 
